### PR TITLE
Conditional column exclusion

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ Release history for Text-Yeti-Table
 
 {{$NEXT}}
 
+v0.1.9     2018-01-12 18:54:56-08:00 America/Los_Angeles (TRIAL RELEASE)
+
+    - Allow column specs as hashrefs
+    - Implement conditional column exclusion
+
 v0.1     2017-08-09 17:47:58-07:00 America/Los_Angeles
 
     - First version

--- a/Changes
+++ b/Changes
@@ -3,6 +3,10 @@ Release history for Text-Yeti-Table
 
 {{$NEXT}}
 
+v0.1.9.1   2018-01-14 19:23:04-08:00 America/Los_Angeles (TRIAL RELEASE)
+
+    - t/03-exclude.t: use List::Util 1.33
+
 v0.1.9     2018-01-12 18:54:56-08:00 America/Los_Angeles (TRIAL RELEASE)
 
     - Allow column specs as hashrefs

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -65,11 +65,11 @@ sub _render_table {
     @len = map { length $_ } @h;
 
     # Compute table rows, keep track of max length
-    my @c    = map { $_->{K} } @spec;
+    my @k    = map { $_->{K} } @spec;
     my @to_s = map { $_->{S} } @spec;
     for my $item (@$items) {
-        my @v = map { $to_s[$_]->( $item->{ $c[$_] }, $item ) } 0 .. $#c;
-        $len[$_] = max( $len[$_], length $v[$_] ) for 0 .. $#c;
+        my @v = map { $to_s[$_]->( $item->{ $k[$_] }, $item ) } 0 .. $#k;
+        $len[$_] = max( $len[$_], length $v[$_] ) for 0 .. $#k;
         push @rows, \@v;
     }
 
@@ -77,11 +77,11 @@ sub _render_table {
     if ( $t->{X} ) {
         my %x;    # Compute exclusions
         for my $i ( @{ $t->{X} } ) {
-            my @w = map { $_->[$i] } @rows;
-            $x{$i}++ if $t->{C}[$i]{X}( \@w );
+            my @c = map { $_->[$i] } @rows;    # Column values
+            $x{$i}++ if $t->{C}[$i]{X}( \@c );
         }
-        if (%x) {    # Exclude
-            my @i = grep { !$x{$_} } 0 .. $#c;
+        if (%x) {                              # Exclude
+            my @i = grep { !$x{$_} } 0 .. $#k;
             @$_ = @{$_}[@i] for @rows, \@len, \@h;
         }
     }

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -12,22 +12,44 @@ our @EXPORT_OK = qw(render_table);
 # default stringification
 my $TO_S = sub { defined $_[0] ? "$_[0]" : "<none>" };
 
+sub _compile_table_spec {
+    my $spec = shift;
+
+    # 'key'
+    # [ 'key', $to_s, 'head' ]
+
+    # { K => 'key', H => 'head', S => $to_s }
+
+    my @columns;
+    for (@$spec) {
+        my @spec = ref $_ ? @$_ : ($_);
+
+        my %spec;
+        $spec{K} = $spec[0];
+        $spec{H} = $spec[2]
+          // do { local $_ = $spec[0]; s/([a-z])([A-Z])/$1 $2/g; uc };
+        $spec{S} = $spec[1] // $TO_S;
+
+        push @columns, \%spec;
+    }
+    return \@columns;
+}
+
 sub _render_table {
     my ( $items, $spec, $io ) = ( shift, shift, shift );
 
+    my @spec = @{ _compile_table_spec($spec) };
+
     my ( @rows, @len );
-    my @spec = map { ref $_ ? $_ : [$_] } @$spec;
-    my @c = map { $_->[0] } @spec;
 
     # Compute table headers
-    my @h = map {
-        $_->[2] // do { local $_ = $_->[0]; s/([a-z])([A-Z])/$1 $2/g; uc }
-    } @spec;
+    my @h = map { $_->{H} } @spec;
     @len = map { length $_ } @h;
     push @rows, \@h;
 
     # Compute table rows, keep track of max length
-    my @to_s = map { $_->[1] // $TO_S } @spec;
+    my @c    = map { $_->{K} } @spec;
+    my @to_s = map { $_->{S} } @spec;
     for my $item (@$items) {
         my @v = map { $to_s[$_]->( $item->{ $c[$_] }, $item ) } 0 .. $#c;
         $len[$_] = max( $len[$_], length $v[$_] ) for 0 .. $#c;

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -12,6 +12,9 @@ our @EXPORT_OK = qw(render_table);
 # default stringification
 my $TO_S = sub { defined $_[0] ? "$_[0]" : "<none>" };
 
+# default header computation (from column key)
+my $TO_H = sub { local $_ = $_[0]; s/([a-z])([A-Z])/$1 $2/g; uc };
+
 sub _compile_table_spec {
     my $spec = shift;
 
@@ -30,16 +33,14 @@ sub _compile_table_spec {
         if ( ref eq 'HASH' ) {
             my %spec = %$_;
             $c{K} = $spec{k};
-            $c{H} = $spec{h}
-              // do { local $_ = $spec{k}; s/([a-z])([A-Z])/$1 $2/g; uc };
+            $c{H} = $spec{h} // $TO_H->( $spec{k} );
             $c{S} = $spec{s} // $TO_S;
             $c{X} = $spec{x} if $spec{x};
         }
         else {
             my @spec = ref $_ ? @$_ : ($_);
             $c{K} = $spec[0];
-            $c{H} = $spec[2]
-              // do { local $_ = $spec[0]; s/([a-z])([A-Z])/$1 $2/g; uc };
+            $c{H} = $spec[2] // $TO_H->( $spec[0] );
             $c{S} = $spec[1] // $TO_S;
         }
         push @columns, \%c;

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -45,7 +45,6 @@ sub _render_table {
     # Compute table headers
     my @h = map { $_->{H} } @spec;
     @len = map { length $_ } @h;
-    push @rows, \@h;
 
     # Compute table rows, keep track of max length
     my @c    = map { $_->{K} } @spec;
@@ -60,6 +59,7 @@ sub _render_table {
     my $fmt = join( " " x 3, map {"%-${_}s"} @len ) . "\n";
 
     # Render the table
+    printf {$io} $fmt, @h;
     printf {$io} $fmt, @$_ for @rows;
 }
 

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -80,7 +80,7 @@ sub _render_table {
         my %x;    # Compute exclusions
         for my $i ( @{ $t->{X} } ) {
             my @c = map { $_->[$i] } @rows;    # Column values
-            $x{$i}++ if $t->{C}[$i]{X}( \@c );
+            $x{$i}++ if $spec[$i]{X}( \@c );
         }
         if (%x) {                              # Exclude
             my @keep = grep { !$x{$_} } @i;

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -65,11 +65,12 @@ sub _render_table {
     @len = map { length $_ } @h;
 
     # Compute table rows, keep track of max length
+    my @i    = 0 .. $#spec;
     my @k    = map { $_->{K} } @spec;
     my @to_s = map { $_->{S} } @spec;
     for my $item (@$items) {
-        my @v = map { $to_s[$_]->( $item->{ $k[$_] }, $item ) } 0 .. $#k;
-        $len[$_] = max( $len[$_], length $v[$_] ) for 0 .. $#k;
+        my @v = map { $to_s[$_]->( $item->{ $k[$_] }, $item ) } @i;
+        $len[$_] = max( $len[$_], length $v[$_] ) for @i;
         push @rows, \@v;
     }
 
@@ -81,8 +82,8 @@ sub _render_table {
             $x{$i}++ if $t->{C}[$i]{X}( \@c );
         }
         if (%x) {                              # Exclude
-            my @i = grep { !$x{$_} } 0 .. $#k;
-            @$_ = @{$_}[@i] for @rows, \@len, \@h;
+            my @keep = grep { !$x{$_} } @i;
+            @$_ = @{$_}[@keep] for @rows, \@len, \@h;
         }
     }
 

--- a/lib/Text/Yeti/Table.pm
+++ b/lib/Text/Yeti/Table.pm
@@ -189,7 +189,7 @@ L<Text::Yeti::Table> implements the following functions, which can be imported i
     render_table( \@items, $spec );
     render_table( \@items, $spec, $io );
 
-The C<$spec> is an arrayref whose entries are:
+The C<$spec> is an arrayref whose entries can be:
 
 =over 4
 
@@ -214,6 +214,33 @@ By default, it is computed from the key, as in the examples below:
 
     "image"       -> "IMAGE"
     "ContainerID" -> "CONTAINER ID"
+
+=item *
+
+a hashref, with keys
+
+    k => 'key',       required
+    s => $to_s,
+    h => $header,
+    x => $exclude,
+
+where
+
+C<$to_s> is a function to convert the value under C<k> to text.
+By default, C<undef> becomes C<< '<none>' >>, and everything else
+is stringfied.
+
+C<$header> is the header for the corresponding column.
+If not given, it is computed from the key as above.
+
+C<$exclude> is a coderef which given all the values of a column
+(as an arrayref) should return true if the column should be excluded
+or false if the column is to be kept. As an example,
+
+    use List::Util 'all';
+    (x => sub { all { $_ eq '<none>' } @{$_[0]} })
+
+will exclude the corresponding column if all values collapse to C<< '<none>' >>.
 
 =back
 

--- a/t/03-exclude.t
+++ b/t/03-exclude.t
@@ -1,0 +1,66 @@
+
+use Mojo::Base -strict;
+use Test::More;
+use Test::Differences;
+use List::Util 'all';
+
+use Text::Yeti::Table qw(render_table);
+
+sub render_to_string {
+    open my $io, '>', \my $buf
+      or die "Can't open in-core file: $!";
+    render_table( @_, $io );
+    return $buf;
+}
+
+{
+    my @items = (    #
+        { a => 1, b => 'x', c => undef, },
+        { a => 2, b => 'y', c => undef },
+    );
+
+    my $spec = [
+        'a', 'b',
+        {   k => 'c',
+            x => sub {
+                all { $_ eq '<none>' } @{ $_[0] };
+            }
+        }
+    ];
+
+    eq_or_diff( render_to_string( \@items, $spec ), <<TABLE );
+A   B
+1   x
+2   y
+TABLE
+
+    eq_or_diff( render_to_string( \@items, [ 'a', 'b', 'c' ] ), <<TABLE );
+A   B   C     
+1   x   <none>
+2   y   <none>
+TABLE
+}
+
+{
+    my @items = (    #
+        { a => 1, b => 'x', c => 'ok', },
+        { a => 2, b => 'y', c => undef },
+    );
+
+    my $spec = [
+        'a', 'b',
+        {   k => 'c',
+            x => sub {
+                all { $_ eq '<none>' } @{ $_[0] };
+            }
+        }
+    ];
+
+    eq_or_diff( render_to_string( \@items, $spec ), <<TABLE );
+A   B   C     
+1   x   ok    
+2   y   <none>
+TABLE
+}
+
+done_testing;

--- a/t/03-exclude.t
+++ b/t/03-exclude.t
@@ -2,7 +2,7 @@
 use Mojo::Base -strict;
 use Test::More;
 use Test::Differences;
-use List::Util 'all';
+use List::Util 1.33 'all';
 
 use Text::Yeti::Table qw(render_table);
 


### PR DESCRIPTION

Allow column specs as hashrefs and implement conditional exclusion


Allow column specs as hashrefs and implement conditional exclusion  …
Column specs as hashrefs mean those are equivalent
```
    'key'
    ['key']
    { k => 'key' }
```
as well as
```
    ['key', $to_s, 'head']
    { k => 'key', s => $to_s, h => 'head' }
```
Additional, there is an "x" option which should be a coderef
which given all the values of a column (as an arrayref)
will return true if the column should be excluded or false otherwise.
```
    use List::Util 'all';

    ...
    { k => 'Name',
      x => sub { all { $_ eq '<none>' } @$_ }
    }
```